### PR TITLE
enhancement: let user know when authenticated but unverified

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -6,18 +6,19 @@ exports.authenticate = (email, password) => {
 	return new Promise(async (resolve, reject) => {
 		try {
 			const user = await User.findOne({ email });
-			if (!user.verified) {
-				reject("Authentication failed.");
-			} else {
-				bcrypt.compare(password, user.password, (err, isMatch) => {
-					if (err) throw err;
-					if (isMatch) {
-						resolve(user);
+
+			bcrypt.compare(password, user.password, (err, isMatch) => {
+				if (err) throw err;
+				if (isMatch) {
+					if (!user.verified) {
+						reject("Unverified user.");
 					} else {
-						reject("Authentication failed.");
+						resolve(user);
 					}
-				});
-			}
+				} else {
+					reject("Authentication failed.");
+				}
+			});
 		} catch (err) {
 			// email not found
 			reject("Authentication failed");


### PR DESCRIPTION
When a unverified users log in with valid credentials, an "Unverified User" error is returned instead of "Authentication Error".

This should resolve issue #30